### PR TITLE
Makes the root volume size configurable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -371,15 +371,15 @@ resource "aws_elastic_beanstalk_environment" "fcrepo" {
   }
 
   setting {
-    namespace = "aws:elasticbeanstalk:environment"
-    name      = "EnvironmentType"
-    value     = "SingleInstance"
-  }
-
-  setting {
     namespace = "aws:ec2:instances"
     name      = "InstanceTypes"
     value     = var.instance_class
+  }
+
+  setting {
+    namespace = "aws:autoscaling:launchconfiguration"
+    name      = "RootVolumeSize"
+    value     = var.root_volume_size
   }
 
   setting {

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,11 @@ variable "new_volume_size" {
   default     = 10
 }
 
+variable "root_volume_size" {
+  description = "The size in GBs of the root volume"
+  default     =  10
+}
+
 variable "instance_class" {
   description = "The Fedora ec2 instance class"
   default     = "t3.small"


### PR DESCRIPTION
Adds the `root_volume_size` parameter.  It is 10 (GB) by default. It can be set via the command line like so:  `-var root_volume_size=25`